### PR TITLE
Backwards support for Django 1.7

### DIFF
--- a/simple_audit/migrations/0001_initial.py
+++ b/simple_audit/migrations/0001_initial.py
@@ -8,7 +8,7 @@ from django.conf import settings
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('contenttypes', '0002_remove_content_type_name'),
+        ('contenttypes', '0001_initial'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
     ]
 


### PR DESCRIPTION
R4R @dinie 

Django 1.7 doesn't have the second migration for the contenttypes app, so we shouldn't depend on it unnecessarily.